### PR TITLE
use correct pkg-config name for libsodium

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,6 +26,7 @@ pattern_prefix = libsodium-
 pattern_version = ([\d\.]+)
 pattern_suffix = \.tar\.gz
 pattern = libsodium-([\d\.]+)\.tar\.gz
+isolate_dynamic = 1
 
 build_command = %pconfigure --prefix=%s --with-pic
 

--- a/dist.ini
+++ b/dist.ini
@@ -21,7 +21,7 @@ skiptest = use_strict
 
 [Alien]
 repo = file:inc
-name = sodium
+name = libsodium
 pattern_prefix = libsodium-
 pattern_version = ([\d\.]+)
 pattern_suffix = \.tar\.gz


### PR DESCRIPTION
This allows using this system libsodium if it is available.
