### PR TITLE
require at least libsodium 1.0.3

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -27,6 +27,8 @@ pattern_version = ([\d\.]+)
 pattern_suffix = \.tar\.gz
 pattern = libsodium-([\d\.]+)\.tar\.gz
 isolate_dynamic = 1
+version_check = %{pkg_config} --modversion %n --atleast-version=1.0.3
+helper = pkg_config = Alien::Base::PkgConfig->pkg_config_command
 
 build_command = %pconfigure --prefix=%s --with-pic
 


### PR DESCRIPTION
Alternatively you can use `--exact-version` instead of `--atleast-version`
