### PR TITLE
use %c instead of %p for configure

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -37,7 +37,7 @@ isolate_dynamic = 1
 version_check = %{pkg_config} --exists '%n = 1.0.3' && %{pkg_config} --modversion %n
 helper = pkg_config = Alien::Base::PkgConfig->pkg_config_command
 
-build_command = %pconfigure --prefix=%s --with-pic
+build_command = %c --prefix=%s --with-pic
 
 install_command = make install
 


### PR DESCRIPTION
This will make it work on Windows (right now showing up as yellow in the matrix).  I was just able to install on my Windows 7 box using Strawberry.  I was also able to get the latest version of `Crypt::NaCl::Sodium` to install on the same machine.

%p is not really portable as it wanted to be.  %c is specifically for configure.
