### PR TITLE
ensure AB::MB is specified as configure_requires

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -27,6 +27,7 @@ Alien::Base = 0.021
 Alien::Base = 0.021
 
 [Alien]
+:version = 0.023
 repo = file:inc
 name = libsodium
 pattern_prefix = libsodium-


### PR DESCRIPTION
This specifies a recent enough version of the [Alien] plugin to ensure that `Alien::Base::ModuleBuild` will correctly be specified as the configure_requires instead of `Alien::Base`.  For more details on the rationale of this change, please see https://github.com/Perl5-Alien/Alien-Base/issues/157
